### PR TITLE
Merge development into staging (4.6.4-staging.13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@nodots-llc/backgammon-cli",
-  "version": "4.6.4-staging.11",
+  "version": "4.6.4-staging.12",
   "description": "Command-line backgammon client for Nodots Backgammon",
   "main": "dist/index.js",
   "bin": {
     "ndbg": "dist/index.js"
   },
   "scripts": {
-    "preinstall": "node -e \"if(parseInt(process.versions.node.split('.')[0],10)!==20){console.error('\\x1b[31mFATAL: Node.js 20.x required, found '+process.versions.node+'\\x1b[0m');process.exit(1)}\"",
     "build": "tsc -b --force",
     "postbuild": "chmod +x dist/index.js",
     "start": "node dist/index.js",
@@ -70,6 +69,6 @@
     "typescript": "^5.3.2"
   },
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots-llc/backgammon-cli",
-  "version": "4.6.4-staging.9",
+  "version": "4.6.4-staging.10",
   "description": "Command-line backgammon client for Nodots Backgammon",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "typescript": "^5.3.2"
   },
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "typescript": "^5.3.2"
   },
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "ndbg": "dist/index.js"
   },
   "scripts": {
-    "preinstall": "node -e \"if(parseInt(process.versions.node.split('.')[0],10)!==20){console.error('\\x1b[31mFATAL: Node.js 20.x required, found '+process.versions.node+'\\x1b[0m');process.exit(1)}\"",
     "build": "tsc -b --force",
     "postbuild": "chmod +x dist/index.js",
     "start": "node dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots-llc/backgammon-cli",
-  "version": "4.6.4-staging.12",
+  "version": "4.6.4-staging.13",
   "description": "Command-line backgammon client for Nodots Backgammon",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots-llc/backgammon-cli",
-  "version": "4.6.4-staging.11",
+  "version": "4.6.4-staging.13",
   "description": "Command-line backgammon client for Nodots Backgammon",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Merge development branch into staging for release 4.6.4-staging.13
- Includes all changes since last staging sync

## Changes in this release
- fix(core): sequence-dependent moves killed by sanitization step
- fix(api): PR calculation for queue-driven robot games
- fix(api): synchronous roll-dice history recording
- fix: widen node engine constraints to >=20
- test(e2e): GNU-vs-GNU multi-game spec
- chore: version bumps to 4.6.4-staging.13