### PR TITLE
fix(cli): remove stale Node 20 runtime guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/backgammon-cli",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Command-line backgammon client for Nodots Backgammon",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,4 @@
 #!/usr/bin/env node
-// Node version check - MUST be first, before any imports that trigger native addon loading
-const REQUIRED_NODE_MAJOR = 20;
-const currentMajor = parseInt(process.versions.node.split('.')[0], 10);
-if (currentMajor !== REQUIRED_NODE_MAJOR) {
-  console.error('\x1b[31m%s\x1b[0m', '╔═══════════════════════════════════════════════════════════════╗');
-  console.error('\x1b[31m%s\x1b[0m', '║  FATAL: Wrong Node.js version                                 ║');
-  console.error('\x1b[31m%s\x1b[0m', '╠═══════════════════════════════════════════════════════════════╣');
-  console.error('\x1b[31m%s\x1b[0m', `║  Required: Node.js ${REQUIRED_NODE_MAJOR}.x                                        ║`);
-  console.error('\x1b[31m%s\x1b[0m', `║  Current:  Node.js ${process.versions.node.padEnd(20)}                    ║`);
-  console.error('\x1b[31m%s\x1b[0m', '╠═══════════════════════════════════════════════════════════════╣');
-  console.error('\x1b[31m%s\x1b[0m', '║  The gnubg-hints native addon requires Node.js 20.            ║');
-  console.error('\x1b[31m%s\x1b[0m', '║  Fix: Run `nvm use 20` then try again.                        ║');
-  console.error('\x1b[31m%s\x1b[0m', '╚═══════════════════════════════════════════════════════════════╝');
-  process.exit(1);
-}
-
 import chalk from 'chalk'
 import { Command } from 'commander'
 import 'dotenv/config'


### PR DESCRIPTION
Preinstall guard was removed in c286fd6 but src/index.ts runtime check was missed.