### PR TITLE
feat(cli): gnubg-style interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,33 @@ ndbg login
 ndbg logout
 ```
 
-## Play a game
+## Interactive shell
+
+Run `ndbg` with no arguments to drop into a gnubg-style REPL:
+
+```sh
+ndbg
+```
+
+```text
+ndbg> help
+ndbg> new <opponent-user-id> [--robot]
+ndbg [3f9a…]> roll
+ndbg [3f9a…]> move 8/5 6/5
+ndbg [3f9a…]> hint
+ndbg [3f9a…]> show board
+ndbg [3f9a…]> save my-game
+ndbg [3f9a…]> quit
+```
+
+Notes:
+
+- Tab completes commands, `show` subtargets, and saved-game names.
+- Command history persists in `~/.ndbg_history` (use the up arrow to recall).
+- Saved-game name -> game-id mappings are stored in `~/.ndbg/games.json`. Use `load <name>` from any future session to reattach.
+- Move notation matches gnubg: `8/5`, `bar/20`, `6/off`, chained `13/8/5`.
+
+## Play a game (one-shot commands)
 
 Start a human-vs-robot game, then roll and move:
 

--- a/src/__tests__/shell-completer.test.ts
+++ b/src/__tests__/shell-completer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, jest } from '@jest/globals'
+
+jest.mock('../shell/savedGames', () => ({
+  loadSavedGames: () => ({ alpha: 'g1', beta: 'g2' }),
+}))
+
+import { buildRegistry } from '../shell/commands'
+import { makeCompleter } from '../shell/completer'
+
+describe('shell completer', () => {
+  const registry = buildRegistry()
+  const complete = makeCompleter(registry)
+
+  it('completes top-level command prefixes', () => {
+    const [hits] = complete('he')
+    expect(hits).toContain('help')
+  })
+
+  it('returns the full command list for an empty prefix', () => {
+    const [hits] = complete('')
+    expect(hits.length).toBe(registry.list.length)
+  })
+
+  it('completes show subtargets', () => {
+    const [hits] = complete('show ')
+    expect(hits.sort()).toEqual(['board', 'game', 'pipcount'])
+  })
+
+  it('completes saved-game names for load', () => {
+    const [hits] = complete('load a')
+    expect(hits).toEqual(['alpha'])
+  })
+
+  it('completes saved-game names for forget', () => {
+    const [hits] = complete('forget b')
+    expect(hits).toEqual(['beta'])
+  })
+
+  it('returns no completions for unknown commands', () => {
+    const [hits] = complete('roll something')
+    expect(hits).toEqual([])
+  })
+})

--- a/src/__tests__/shell-dispatch.test.ts
+++ b/src/__tests__/shell-dispatch.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { buildRegistry } from '../shell/commands'
+import { createShellContext } from '../shell/context'
+
+type AnyGame = Record<string, any>
+
+function makeReadyGame(): AnyGame {
+  return {
+    id: 'game-1',
+    stateKind: 'moving',
+    activeColor: 'white',
+    activePlay: {
+      moves: [
+        {
+          stateKind: 'ready',
+          dieValue: 3,
+          possibleMoves: [
+            {
+              origin: {
+                kind: 'point',
+                position: { clockwise: 8, counterclockwise: 17 },
+                checkers: [{ id: 'checker-A', color: 'white' }],
+              },
+              destination: {
+                kind: 'point',
+                position: { clockwise: 5, counterclockwise: 20 },
+                checkers: [],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    players: [
+      {
+        userId: 'me',
+        color: 'white',
+        direction: 'clockwise',
+      },
+    ],
+    board: { points: [], bar: {} },
+    asciiBoard: '<board>',
+  }
+}
+
+function makeMockApi(game: AnyGame): {
+  api: any
+  calls: { makeMove: string[]; confirmTurn: number }
+} {
+  const calls = { makeMove: [] as string[], confirmTurn: 0 }
+  const api = {
+    getGame: jest.fn(async () => ({ success: true, data: game })),
+    createGame: jest.fn(),
+    rollForStart: jest.fn(),
+    rollDice: jest.fn(),
+    makeMove: jest.fn(),
+    makeMoveWithCheckerId: jest.fn(async (_id: string, checkerId: string) => {
+      calls.makeMove.push(checkerId)
+      return { success: true, data: game }
+    }),
+    confirmTurn: jest.fn(async () => {
+      calls.confirmTurn += 1
+      return { success: true, data: game }
+    }),
+  }
+  return { api, calls }
+}
+
+describe('shell dispatcher', () => {
+  it('move resolves notation to a checker id and calls the API', async () => {
+    const game = makeReadyGame()
+    const { api, calls } = makeMockApi(game)
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me', email: 'me@example.com' }
+    )
+    ctx.currentGameId = 'game-1'
+
+    const registry = buildRegistry()
+    const move = registry.byName.get('move')
+    expect(move).toBeDefined()
+    await move!.run(['8/5'], ctx)
+    expect(calls.makeMove).toEqual(['checker-A'])
+  })
+
+  it('move reports no legal move when notation does not match', async () => {
+    const game = makeReadyGame()
+    const { api, calls } = makeMockApi(game)
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me', email: 'me@example.com' }
+    )
+    ctx.currentGameId = 'game-1'
+
+    const errLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const registry = buildRegistry()
+    await registry.byName.get('move')!.run(['7/4'], ctx)
+    expect(calls.makeMove).toEqual([])
+    errLog.mockRestore()
+  })
+
+  it('move bails out when there is no active game', async () => {
+    const { api, calls } = makeMockApi(makeReadyGame())
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me', email: 'me@example.com' }
+    )
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const registry = buildRegistry()
+    await registry.byName.get('move')!.run(['8/5'], ctx)
+    expect(api.getGame).not.toHaveBeenCalled()
+    expect(calls.makeMove).toEqual([])
+    log.mockRestore()
+  })
+
+  it('hint exits cleanly when no active game', async () => {
+    const { api } = makeMockApi(makeReadyGame())
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me' }
+    )
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const registry = buildRegistry()
+    await registry.byName.get('hint')!.run([], ctx)
+    expect(api.getGame).not.toHaveBeenCalled()
+    log.mockRestore()
+  })
+
+  it('confirm calls the API confirm-turn endpoint', async () => {
+    const game = makeReadyGame()
+    const { api, calls } = makeMockApi(game)
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me', email: 'me@example.com' }
+    )
+    ctx.currentGameId = 'game-1'
+
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const registry = buildRegistry()
+    await registry.byName.get('confirm')!.run([], ctx)
+    expect(calls.confirmTurn).toBe(1)
+    log.mockRestore()
+  })
+
+  it('confirm bails out when there is no active game', async () => {
+    const { api, calls } = makeMockApi(makeReadyGame())
+    const ctx = createShellContext(
+      api,
+      {} as any,
+      { userId: 'me', email: 'me@example.com' }
+    )
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const registry = buildRegistry()
+    await registry.byName.get('confirm')!.run([], ctx)
+    expect(calls.confirmTurn).toBe(0)
+    log.mockRestore()
+  })
+
+  it('quit returns exit:true', async () => {
+    const ctx = createShellContext({} as any, {} as any, { userId: 'me' })
+    const registry = buildRegistry()
+    const result = await registry.byName.get('quit')!.run([], ctx)
+    expect(result).toEqual({ exit: true })
+  })
+})

--- a/src/__tests__/shell-move-parser.test.ts
+++ b/src/__tests__/shell-move-parser.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals'
+import { parseMoveNotation } from '../shell/moveParser'
+
+describe('parseMoveNotation', () => {
+  it('parses a simple from/to', () => {
+    const result = parseMoveNotation(['8/5'])
+    expect(result.errors).toEqual([])
+    expect(result.segments).toEqual([{ from: 8, to: 5 }])
+  })
+
+  it('parses bar entry', () => {
+    const result = parseMoveNotation(['bar/20'])
+    expect(result.segments).toEqual([{ from: 'bar', to: 20 }])
+  })
+
+  it('parses bear-off', () => {
+    const result = parseMoveNotation(['6/off'])
+    expect(result.segments).toEqual([{ from: 6, to: 'off' }])
+  })
+
+  it('expands chained notation into segments', () => {
+    const result = parseMoveNotation(['13/8/5'])
+    expect(result.segments).toEqual([
+      { from: 13, to: 8 },
+      { from: 8, to: 5 },
+    ])
+  })
+
+  it('parses multiple tokens', () => {
+    const result = parseMoveNotation(['8/5', '6/5'])
+    expect(result.segments).toEqual([
+      { from: 8, to: 5 },
+      { from: 6, to: 5 },
+    ])
+  })
+
+  it('reports an error for out-of-range points', () => {
+    const result = parseMoveNotation(['30/5'])
+    expect(result.segments).toEqual([])
+    expect(result.errors.length).toBe(1)
+  })
+
+  it('reports an error when no slash', () => {
+    const result = parseMoveNotation(['85'])
+    expect(result.segments).toEqual([])
+    expect(result.errors.length).toBe(1)
+  })
+
+  it('accepts short forms b and o', () => {
+    const result = parseMoveNotation(['b/20', '6/o'])
+    expect(result.segments).toEqual([
+      { from: 'bar', to: 20 },
+      { from: 6, to: 'off' },
+    ])
+  })
+})

--- a/src/__tests__/shell-tokenize.test.ts
+++ b/src/__tests__/shell-tokenize.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals'
+import { tokenize } from '../shell/tokenize'
+
+describe('tokenize', () => {
+  it('splits on whitespace', () => {
+    expect(tokenize('show board')).toEqual(['show', 'board'])
+  })
+
+  it('handles tabs and multiple spaces', () => {
+    expect(tokenize('move   8/5\t6/5')).toEqual(['move', '8/5', '6/5'])
+  })
+
+  it('keeps quoted arguments as one token', () => {
+    expect(tokenize('save "my opening trap"')).toEqual([
+      'save',
+      'my opening trap',
+    ])
+  })
+
+  it('handles single quotes', () => {
+    expect(tokenize("save 'two words'")).toEqual(['save', 'two words'])
+  })
+
+  it('returns an empty array for blank input', () => {
+    expect(tokenize('   ')).toEqual([])
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ import { GameStatusCommand } from './commands/game-status'
 import { HumanVsRobotCommand } from './commands/human-vs-robot'
 import { RobotVsRobotCommand } from './commands/robot-vs-robot'
 
+// Interactive shell
+import { runShell } from './shell'
+
 async function checkAuthenticationAndPrompt(): Promise<void> {
   const authService = new AuthService()
 
@@ -132,6 +135,12 @@ async function main() {
   try {
     // Check authentication before processing commands
     await checkAuthenticationAndPrompt()
+
+    // No subcommand given: drop into the interactive shell
+    if (process.argv.length === 2) {
+      await runShell()
+      return
+    }
 
     // Parse and execute commands
     program.parse()

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -142,6 +142,17 @@ export class ApiService {
     }
   }
 
+  async confirmTurn(gameId: string): Promise<ApiResponse<BackgammonGame>> {
+    try {
+      const response = await this.client.post(
+        `/api/${this.apiVersion}/games/${gameId}/confirm-turn`
+      )
+      return { success: true, data: this.unwrap<BackgammonGame>(response.data) }
+    } catch (error) {
+      return this.handleError(error)
+    }
+  }
+
   async makeMoveWithCheckerId(
     gameId: string,
     checkerId: string

--- a/src/shell/commands.ts
+++ b/src/shell/commands.ts
@@ -1,0 +1,516 @@
+import chalk from 'chalk'
+import { ShellContext } from './context'
+import { parseMoveNotation, ParsedSegment, Point } from './moveParser'
+import {
+  containerLabel,
+  printBoard,
+  printGameSummary,
+  printHint,
+  printPipCount,
+} from './render'
+import {
+  deleteSavedGame,
+  loadSavedGames,
+  saveGame,
+} from './savedGames'
+
+type AnyGame = Record<string, any>
+
+export interface CommandResult {
+  exit?: boolean
+}
+
+export interface CommandDef {
+  name: string
+  args?: string
+  summary: string
+  details?: string
+  run: (args: string[], ctx: ShellContext) => Promise<CommandResult | void>
+}
+
+export interface CommandRegistry {
+  list: CommandDef[]
+  byName: Map<string, CommandDef>
+}
+
+export function buildRegistry(): CommandRegistry {
+  const list: CommandDef[] = [
+    {
+      name: 'help',
+      args: '[command]',
+      summary: 'Show help for all commands or one command',
+      run: helpCmd,
+    },
+    {
+      name: 'new',
+      args: '[opponent-user-id] [--robot]',
+      summary: 'Start a new game against another user (or robot)',
+      details:
+        "With a user id, plays against that user. With --robot, picks the first available robot (or use --robot=<id> for a specific one). The new game becomes the shell's active game.",
+      run: newGameCmd,
+    },
+    {
+      name: 'robots',
+      summary: 'List robot users available as opponents',
+      run: robotsCmd,
+    },
+    {
+      name: 'attach',
+      args: '<game-id>',
+      summary: "Make an existing server game the shell's active game",
+      run: attachCmd,
+    },
+    {
+      name: 'detach',
+      summary: 'Forget the active game (does not delete it on the server)',
+      run: async (_args, ctx) => {
+        ctx.currentGameId = null
+        console.log(chalk.gray('Detached.'))
+      },
+    },
+    {
+      name: 'roll',
+      summary: 'Roll for start, or roll your dice',
+      run: rollCmd,
+    },
+    {
+      name: 'move',
+      args: '<from/to> [<from/to> ...]',
+      summary: 'Play moves using gnubg notation (e.g. move 8/5 6/5)',
+      details:
+        'Examples: move 8/5 6/5, move bar/20, move 6/off, move 13/8/5 (same checker via 8).',
+      run: moveCmd,
+    },
+    {
+      name: 'hint',
+      summary: 'List the legal moves for the current dice',
+      run: hintCmd,
+    },
+    {
+      name: 'confirm',
+      summary: 'Confirm your turn and pass play to the opponent',
+      details:
+        'Finalizes the current turn after you have moved all of your dice. The game must be in the `moved` state.',
+      run: confirmCmd,
+    },
+    {
+      name: 'show',
+      args: '<board|pipcount|game>',
+      summary: 'Display board, pip counts, or game summary',
+      run: showCmd,
+    },
+    {
+      name: 'save',
+      args: '<name>',
+      summary: 'Save the active game id under a name in ~/.ndbg/games.json',
+      run: saveCmd,
+    },
+    {
+      name: 'load',
+      args: '<name|game-id>',
+      summary: 'Attach to a saved game by name (or raw game id)',
+      run: loadCmd,
+    },
+    {
+      name: 'list',
+      summary: 'List saved games',
+      run: listCmd,
+    },
+    {
+      name: 'forget',
+      args: '<name>',
+      summary: 'Remove a saved game from ~/.ndbg/games.json',
+      run: forgetCmd,
+    },
+    {
+      name: 'whoami',
+      summary: 'Show the logged-in user',
+      run: async (_args, ctx) => {
+        const u = ctx.user
+        console.log(
+          `${u.email ?? u.userId} (userId=${u.userId ?? 'unknown'})`
+        )
+      },
+    },
+    {
+      name: 'quit',
+      summary: 'Exit the shell',
+      run: async () => ({ exit: true }),
+    },
+    {
+      name: 'exit',
+      summary: 'Exit the shell',
+      run: async () => ({ exit: true }),
+    },
+  ]
+
+  const byName = new Map(list.map((c) => [c.name, c]))
+  return { list, byName }
+}
+
+function requireGame(ctx: ShellContext): string | null {
+  if (!ctx.currentGameId) {
+    console.log(
+      chalk.yellow(
+        "No active game. Use 'new', 'attach <id>', or 'load <name>' first."
+      )
+    )
+    return null
+  }
+  return ctx.currentGameId
+}
+
+async function fetchGame(ctx: ShellContext): Promise<AnyGame | null> {
+  const id = requireGame(ctx)
+  if (!id) return null
+  const resp = await ctx.api.getGame(id)
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Failed to fetch game: ${resp.error}`))
+    return null
+  }
+  return resp.data as AnyGame
+}
+
+function findMyPlayer(game: AnyGame, userId: string): AnyGame | null {
+  const players = Array.isArray(game.players) ? game.players : []
+  return players.find((p: AnyGame) => p.userId === userId) ?? null
+}
+
+async function helpCmd(args: string[], ctx: ShellContext): Promise<void> {
+  const registry = buildRegistry()
+  if (args.length === 0) {
+    console.log(chalk.bold('Commands:'))
+    for (const cmd of registry.list) {
+      const sig = cmd.args ? `${cmd.name} ${cmd.args}` : cmd.name
+      console.log(`  ${sig.padEnd(38)} ${cmd.summary}`)
+    }
+    console.log('')
+    console.log("Type 'help <command>' for details.")
+    return
+  }
+  const cmd = registry.byName.get(args[0])
+  if (!cmd) {
+    console.log(chalk.yellow(`Unknown command: ${args[0]}`))
+    return
+  }
+  const sig = cmd.args ? `${cmd.name} ${cmd.args}` : cmd.name
+  console.log(chalk.bold(sig))
+  console.log(`  ${cmd.summary}`)
+  if (cmd.details) console.log(`  ${cmd.details}`)
+}
+
+async function newGameCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (!ctx.user.userId) {
+    console.log(chalk.red('No userId on logged-in user; cannot create game.'))
+    return
+  }
+
+  const positional: string[] = []
+  let robotFlag = false
+  let robotIdFromFlag: string | null = null
+  for (const a of args) {
+    if (a === '--robot') {
+      robotFlag = true
+    } else if (a.startsWith('--robot=')) {
+      robotFlag = true
+      robotIdFromFlag = a.slice('--robot='.length) || null
+    } else if (a.startsWith('--')) {
+      console.log(chalk.yellow(`Unknown flag: ${a}`))
+      return
+    } else {
+      positional.push(a)
+    }
+  }
+
+  let opponentId: string | null = positional[0] ?? robotIdFromFlag ?? null
+
+  if (!opponentId && robotFlag) {
+    opponentId = await pickFirstRobot(ctx)
+    if (!opponentId) return
+  }
+
+  if (!opponentId) {
+    console.log(
+      chalk.yellow('Usage: new <opponent-user-id> | new --robot [--robot=<id>]')
+    )
+    return
+  }
+
+  const resp = await ctx.api.createGame(ctx.user.userId, opponentId, {
+    player2IsRobot: robotFlag,
+  })
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Create failed: ${resp.error}`))
+    return
+  }
+  const game = resp.data as AnyGame
+  ctx.currentGameId = game.id
+  console.log(chalk.green(`Created game ${game.id}`))
+  printBoard(game)
+}
+
+async function pickFirstRobot(ctx: ShellContext): Promise<string | null> {
+  const resp = await ctx.api.getUsers()
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Failed to fetch users: ${resp.error}`))
+    return null
+  }
+  const robots = (resp.data as AnyGame[]).filter(
+    (u) => u.userType === 'robot'
+  )
+  if (robots.length === 0) {
+    console.log(chalk.red('No robot users available on the server.'))
+    return null
+  }
+  const robot = robots[0]
+  console.log(
+    chalk.gray(
+      `Picking robot: ${robot.firstName ?? ''} ${robot.lastName ?? ''} (${
+        robot.id
+      })`
+    )
+  )
+  return robot.id
+}
+
+async function robotsCmd(_args: string[], ctx: ShellContext): Promise<void> {
+  const resp = await ctx.api.getUsers()
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Failed to fetch users: ${resp.error}`))
+    return
+  }
+  const robots = (resp.data as AnyGame[]).filter(
+    (u) => u.userType === 'robot'
+  )
+  if (robots.length === 0) {
+    console.log(chalk.gray('(no robots)'))
+    return
+  }
+  for (const r of robots) {
+    const name = `${r.firstName ?? ''} ${r.lastName ?? ''}`.trim()
+    console.log(`  ${r.id.padEnd(40)} ${name || r.email || ''}`)
+  }
+}
+
+async function attachCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: attach <game-id>'))
+    return
+  }
+  const id = args[0]
+  const resp = await ctx.api.getGame(id)
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Cannot attach: ${resp.error}`))
+    return
+  }
+  ctx.currentGameId = id
+  console.log(chalk.green(`Attached to ${id}`))
+  printBoard(resp.data as AnyGame)
+}
+
+async function rollCmd(_args: string[], ctx: ShellContext): Promise<void> {
+  const game = await fetchGame(ctx)
+  if (!game) return
+  const id = ctx.currentGameId as string
+  let resp
+  if (game.stateKind === 'rolling-for-start') {
+    resp = await ctx.api.rollForStart(id)
+  } else if (
+    game.stateKind === 'rolled-for-start' ||
+    game.stateKind === 'rolling'
+  ) {
+    resp = await ctx.api.rollDice(id)
+  } else {
+    console.log(
+      chalk.yellow(`Cannot roll in state '${game.stateKind}'.`)
+    )
+    return
+  }
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Roll failed: ${resp.error}`))
+    return
+  }
+  printBoard(resp.data as AnyGame)
+}
+
+async function moveCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: move <from/to> [<from/to> ...]'))
+    return
+  }
+  const parsed = parseMoveNotation(args)
+  for (const e of parsed.errors) console.log(chalk.red(e))
+  if (parsed.segments.length === 0) return
+
+  for (const segment of parsed.segments) {
+    const game = await fetchGame(ctx)
+    if (!game) return
+    if (!ctx.user.userId) {
+      console.log(chalk.red('No userId; cannot move.'))
+      return
+    }
+    const me = findMyPlayer(game, ctx.user.userId)
+    if (!me) {
+      console.log(chalk.red('You are not a player in this game.'))
+      return
+    }
+    if (game.activeColor !== me.color) {
+      console.log(
+        chalk.yellow(`Not your turn (active=${game.activeColor}).`)
+      )
+      return
+    }
+    const checkerId = resolveMoveToChecker(game, me, segment)
+    if (!checkerId) {
+      console.log(
+        chalk.red(
+          `No legal move ${formatPoint(segment.from)}/${formatPoint(
+            segment.to
+          )} for current dice. Use 'hint' to see options.`
+        )
+      )
+      return
+    }
+    const resp = await ctx.api.makeMoveWithCheckerId(
+      ctx.currentGameId as string,
+      checkerId
+    )
+    if (!resp.success || !resp.data) {
+      console.error(chalk.red(`Move failed: ${resp.error}`))
+      return
+    }
+  }
+  const final = await fetchGame(ctx)
+  if (final) {
+    printBoard(final)
+    if (final.stateKind === 'moved') {
+      console.log(
+        chalk.cyanBright(
+          "All dice consumed. Type 'confirm' to end your turn and pass play."
+        )
+      )
+    }
+  }
+}
+
+function formatPoint(p: Point): string {
+  return typeof p === 'number' ? String(p) : p
+}
+
+function resolveMoveToChecker(
+  game: AnyGame,
+  me: AnyGame,
+  segment: ParsedSegment
+): string | null {
+  const moves = Array.isArray(game.activePlay?.moves)
+    ? game.activePlay.moves
+    : []
+  const ready = moves.filter((m: AnyGame) => m.stateKind === 'ready')
+  const target = (label: string, kind: 'origin' | 'destination'): boolean => {
+    return label === formatPoint(kind === 'origin' ? segment.from : segment.to)
+  }
+  for (const move of ready) {
+    for (const pm of move.possibleMoves ?? []) {
+      const fromLabel = containerLabel(pm.origin, me.direction)
+      const toLabel = containerLabel(pm.destination, me.direction)
+      if (target(fromLabel, 'origin') && target(toLabel, 'destination')) {
+        const checker = (pm.origin?.checkers ?? []).find(
+          (c: AnyGame) => c.color === me.color
+        )
+        if (checker?.id) return checker.id
+      }
+    }
+  }
+  return null
+}
+
+async function confirmCmd(_args: string[], ctx: ShellContext): Promise<void> {
+  const id = requireGame(ctx)
+  if (!id) return
+  const resp = await ctx.api.confirmTurn(id)
+  if (!resp.success || !resp.data) {
+    console.error(chalk.red(`Confirm failed: ${resp.error}`))
+    return
+  }
+  const game = resp.data as AnyGame
+  console.log(chalk.green('Turn confirmed. Opponent to play.'))
+  printBoard(game)
+}
+
+async function hintCmd(_args: string[], ctx: ShellContext): Promise<void> {
+  const game = await fetchGame(ctx)
+  if (!game) return
+  if (!ctx.user.userId) return
+  const me = findMyPlayer(game, ctx.user.userId)
+  if (!me) {
+    console.log(chalk.red('You are not a player in this game.'))
+    return
+  }
+  printHint(game, me.direction)
+}
+
+async function showCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: show <board|pipcount|game>'))
+    return
+  }
+  const sub = args[0]
+  const game = await fetchGame(ctx)
+  if (!game) return
+  switch (sub) {
+    case 'board':
+      printBoard(game)
+      return
+    case 'pipcount':
+      printPipCount(game)
+      return
+    case 'game':
+      printGameSummary(game)
+      return
+    default:
+      console.log(chalk.yellow(`Unknown show target: ${sub}`))
+  }
+}
+
+async function saveCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: save <name>'))
+    return
+  }
+  const id = requireGame(ctx)
+  if (!id) return
+  saveGame(args[0], id)
+  console.log(chalk.green(`Saved '${args[0]}' -> ${id}`))
+}
+
+async function loadCmd(args: string[], ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: load <name|game-id>'))
+    return
+  }
+  const key = args[0]
+  const games = loadSavedGames()
+  const id = games[key] ?? key
+  return attachCmd([id], ctx)
+}
+
+async function listCmd(_args: string[], _ctx: ShellContext): Promise<void> {
+  const games = loadSavedGames()
+  const entries = Object.entries(games)
+  if (entries.length === 0) {
+    console.log(chalk.gray('(no saved games)'))
+    return
+  }
+  for (const [name, id] of entries) {
+    console.log(`  ${name.padEnd(20)} ${id}`)
+  }
+}
+
+async function forgetCmd(args: string[], _ctx: ShellContext): Promise<void> {
+  if (args.length === 0) {
+    console.log(chalk.yellow('Usage: forget <name>'))
+    return
+  }
+  deleteSavedGame(args[0])
+  console.log(chalk.gray(`Forgot '${args[0]}'.`))
+}

--- a/src/shell/completer.ts
+++ b/src/shell/completer.ts
@@ -1,0 +1,40 @@
+import { CommandRegistry } from './commands'
+import { loadSavedGames } from './savedGames'
+
+export type CompleterResult = [string[], string]
+
+export function makeCompleter(
+  registry: CommandRegistry
+): (line: string) => CompleterResult {
+  return (line: string): CompleterResult => {
+    const tokens = line.split(/\s+/)
+    const atFirstToken = tokens.length <= 1
+    const last = tokens[tokens.length - 1] ?? ''
+
+    if (atFirstToken) {
+      const hits = registry.list
+        .map((c) => c.name)
+        .filter((n) => n.startsWith(last))
+      return [hits, last]
+    }
+
+    const cmd = tokens[0]
+    if (cmd === 'help') {
+      const hits = registry.list
+        .map((c) => c.name)
+        .filter((n) => n.startsWith(last))
+      return [hits, last]
+    }
+    if (cmd === 'load' || cmd === 'forget') {
+      const names = Object.keys(loadSavedGames())
+      const hits = names.filter((n) => n.startsWith(last))
+      return [hits, last]
+    }
+    if (cmd === 'show') {
+      const targets = ['board', 'pipcount', 'game']
+      const hits = targets.filter((n) => n.startsWith(last))
+      return [hits, last]
+    }
+    return [[], last]
+  }
+}

--- a/src/shell/context.ts
+++ b/src/shell/context.ts
@@ -1,0 +1,22 @@
+import { ApiService } from '../services/api'
+import { AuthService, UserProfile } from '../services/auth'
+
+export interface ShellContext {
+  api: ApiService
+  auth: AuthService
+  user: UserProfile
+  currentGameId: string | null
+}
+
+export function createShellContext(
+  api: ApiService,
+  auth: AuthService,
+  user: UserProfile
+): ShellContext {
+  return {
+    api,
+    auth,
+    user,
+    currentGameId: null,
+  }
+}

--- a/src/shell/history.ts
+++ b/src/shell/history.ts
@@ -1,0 +1,25 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+
+const HISTORY_PATH = join(homedir(), '.ndbg_history')
+const MAX_HISTORY = 1000
+
+export function loadHistory(): string[] {
+  if (!existsSync(HISTORY_PATH)) return []
+  try {
+    return readFileSync(HISTORY_PATH, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+  } catch {
+    return []
+  }
+}
+
+export function saveHistory(lines: string[]): void {
+  const trimmed = lines.slice(-MAX_HISTORY)
+  const dir = dirname(HISTORY_PATH)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(HISTORY_PATH, trimmed.join('\n') + '\n', 'utf8')
+}

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -1,0 +1,101 @@
+import chalk from 'chalk'
+import * as readline from 'readline'
+import { ApiService } from '../services/api'
+import { AuthService } from '../services/auth'
+import { CliConfig } from '../types'
+import { buildRegistry, CommandRegistry } from './commands'
+import { makeCompleter } from './completer'
+import { createShellContext, ShellContext } from './context'
+import { loadHistory, saveHistory } from './history'
+import { tokenize } from './tokenize'
+
+function makePrompt(ctx: ShellContext): string {
+  if (!ctx.currentGameId) return 'ndbg> '
+  const short = ctx.currentGameId.slice(0, 8)
+  return `ndbg [${short}]> `
+}
+
+async function dispatch(
+  line: string,
+  ctx: ShellContext,
+  registry: CommandRegistry
+): Promise<{ exit?: boolean }> {
+  const tokens = tokenize(line)
+  if (tokens.length === 0) return {}
+  const [name, ...rest] = tokens
+  const cmd = registry.byName.get(name)
+  if (!cmd) {
+    console.log(
+      chalk.yellow(`Unknown command: ${name}. Type 'help' for a list.`)
+    )
+    return {}
+  }
+  const result = await cmd.run(rest, ctx)
+  return result ?? {}
+}
+
+export async function runShell(): Promise<void> {
+  const auth = new AuthService()
+  const user = auth.getCurrentUser()
+  if (!user) {
+    console.log(chalk.red('Not authenticated. Run: ndbg login'))
+    process.exit(1)
+  }
+
+  const config: Partial<CliConfig> = {
+    apiUrl: process.env.NODOTS_API_URL,
+    userId: user.userId,
+    apiKey: user.token,
+  }
+  const api = new ApiService(config)
+
+  const ctx = createShellContext(api, auth, user)
+  const registry = buildRegistry()
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+    historySize: 1000,
+    completer: makeCompleter(registry),
+  })
+
+  const existing = loadHistory()
+  // readline stores history newest-first internally
+  const rlAny = rl as unknown as { history: string[] }
+  rlAny.history = existing.slice().reverse()
+
+  console.log(chalk.cyanBright('Nodots Backgammon interactive shell.'))
+  console.log(
+    chalk.gray(
+      "Type 'help' for commands. Tab completes. History at ~/.ndbg_history."
+    )
+  )
+  rl.setPrompt(makePrompt(ctx))
+  rl.prompt()
+
+  for await (const raw of rl) {
+    const line = raw.trim()
+    if (line.length === 0) {
+      rl.setPrompt(makePrompt(ctx))
+      rl.prompt()
+      continue
+    }
+    try {
+      const { exit } = await dispatch(line, ctx, registry)
+      if (exit) {
+        rl.close()
+        break
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(chalk.red(`Error: ${msg}`))
+    }
+    rl.setPrompt(makePrompt(ctx))
+    rl.prompt()
+  }
+
+  const finalHistory = (rlAny.history ?? []).slice().reverse()
+  saveHistory(finalHistory)
+  console.log(chalk.gray('Goodbye.'))
+}

--- a/src/shell/moveParser.ts
+++ b/src/shell/moveParser.ts
@@ -1,0 +1,44 @@
+export type Point = number | 'bar' | 'off'
+
+export interface ParsedSegment {
+  from: Point
+  to: Point
+}
+
+export interface ParseResult {
+  segments: ParsedSegment[]
+  errors: string[]
+}
+
+function parsePoint(token: string): Point | null {
+  const t = token.trim().toLowerCase()
+  if (t === 'bar' || t === 'b') return 'bar'
+  if (t === 'off' || t === 'o') return 'off'
+  const n = Number(t)
+  if (Number.isInteger(n) && n >= 1 && n <= 24) return n
+  return null
+}
+
+export function parseMoveNotation(tokens: string[]): ParseResult {
+  const segments: ParsedSegment[] = []
+  const errors: string[] = []
+
+  for (const token of tokens) {
+    const parts = token.split('/')
+    if (parts.length < 2) {
+      errors.push(`Invalid move '${token}': expected from/to`)
+      continue
+    }
+    const points = parts.map(parsePoint)
+    const badIdx = points.findIndex((p) => p === null)
+    if (badIdx >= 0) {
+      errors.push(`Invalid point '${parts[badIdx]}' in '${token}'`)
+      continue
+    }
+    for (let i = 0; i < points.length - 1; i++) {
+      segments.push({ from: points[i] as Point, to: points[i + 1] as Point })
+    }
+  }
+
+  return { segments, errors }
+}

--- a/src/shell/render.ts
+++ b/src/shell/render.ts
@@ -1,0 +1,100 @@
+import chalk from 'chalk'
+
+type AnyGame = Record<string, any>
+
+export function printBoard(game: AnyGame): void {
+  if (game.asciiBoard) {
+    console.log(chalk.cyanBright('Board:'))
+    console.log(game.asciiBoard)
+  } else {
+    console.log(chalk.yellow('No asciiBoard from API'))
+  }
+  console.log(
+    chalk.gray(
+      `state=${game.stateKind} activeColor=${game.activeColor} cube=${
+        game.cube?.value ?? 1
+      }`
+    )
+  )
+}
+
+export function printGameSummary(game: AnyGame): void {
+  console.log(chalk.bold('Game'))
+  console.log(`  id:          ${game.id}`)
+  console.log(`  state:       ${game.stateKind}`)
+  console.log(`  activeColor: ${game.activeColor}`)
+  console.log(`  cube:        ${game.cube?.value ?? 1}`)
+  const players = Array.isArray(game.players) ? game.players : []
+  for (const p of players) {
+    console.log(
+      `  player:      ${p.color} ${p.direction} user=${p.userId} ${
+        p.isRobot ? '(robot)' : ''
+      }`
+    )
+  }
+}
+
+export function printHint(game: AnyGame, direction: string): void {
+  const moves = Array.isArray(game.activePlay?.moves)
+    ? game.activePlay.moves
+    : []
+  const ready = moves.filter((m: any) => m.stateKind === 'ready')
+  if (ready.length === 0) {
+    console.log(chalk.gray('No ready moves.'))
+    return
+  }
+  for (const move of ready) {
+    const dv = move.dieValue
+    const possible = move.possibleMoves ?? []
+    if (possible.length === 0) {
+      console.log(`  die ${dv}: no legal move`)
+      continue
+    }
+    const lines = possible.map((pm: any) => {
+      const from = containerLabel(pm.origin, direction)
+      const to = containerLabel(pm.destination, direction)
+      return `${from}/${to}`
+    })
+    console.log(`  die ${dv}: ${lines.join('  ')}`)
+  }
+}
+
+export function printPipCount(game: AnyGame): void {
+  const points = game.board?.points ?? []
+  const bar = game.board?.bar ?? {}
+  const counts: Record<string, number> = {}
+
+  const addChecker = (color: string, pip: number) => {
+    counts[color] = (counts[color] ?? 0) + pip
+  }
+
+  for (const point of points) {
+    for (const checker of point.checkers ?? []) {
+      const color = checker.color
+      const player = (game.players ?? []).find((p: any) => p.color === color)
+      const direction = player?.direction
+      if (!direction) continue
+      const pip = point.position?.[direction]
+      if (typeof pip === 'number') addChecker(color, pip)
+    }
+  }
+
+  for (const direction of ['clockwise', 'counterclockwise']) {
+    const checkers = bar[direction]?.checkers ?? []
+    for (const checker of checkers) {
+      addChecker(checker.color, 25)
+    }
+  }
+
+  for (const color of Object.keys(counts)) {
+    console.log(`  ${color}: ${counts[color]}`)
+  }
+}
+
+export function containerLabel(container: any, direction: string): string {
+  if (!container) return '?'
+  if (container.kind === 'bar') return 'bar'
+  if (container.kind === 'off') return 'off'
+  const pos = container.position?.[direction]
+  return pos != null ? String(pos) : '?'
+}

--- a/src/shell/savedGames.ts
+++ b/src/shell/savedGames.ts
@@ -1,0 +1,39 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+
+const SAVED_PATH = join(homedir(), '.ndbg', 'games.json')
+
+export type SavedGames = Record<string, string>
+
+export function loadSavedGames(): SavedGames {
+  if (!existsSync(SAVED_PATH)) return {}
+  try {
+    const raw = readFileSync(SAVED_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') return parsed as SavedGames
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeSavedGames(games: SavedGames): void {
+  const dir = dirname(SAVED_PATH)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(SAVED_PATH, JSON.stringify(games, null, 2), 'utf8')
+}
+
+export function saveGame(name: string, gameId: string): SavedGames {
+  const games = loadSavedGames()
+  games[name] = gameId
+  writeSavedGames(games)
+  return games
+}
+
+export function deleteSavedGame(name: string): SavedGames {
+  const games = loadSavedGames()
+  delete games[name]
+  writeSavedGames(games)
+  return games
+}

--- a/src/shell/tokenize.ts
+++ b/src/shell/tokenize.ts
@@ -1,0 +1,30 @@
+export function tokenize(line: string): string[] {
+  const out: string[] = []
+  let i = 0
+  while (i < line.length) {
+    const c = line[i]
+    if (c === ' ' || c === '\t') {
+      i++
+      continue
+    }
+    if (c === '"' || c === "'") {
+      const quote = c
+      i++
+      let buf = ''
+      while (i < line.length && line[i] !== quote) {
+        buf += line[i]
+        i++
+      }
+      if (line[i] === quote) i++
+      out.push(buf)
+      continue
+    }
+    let buf = ''
+    while (i < line.length && line[i] !== ' ' && line[i] !== '\t') {
+      buf += line[i]
+      i++
+    }
+    out.push(buf)
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

- Drop into a REPL when `ndbg` is invoked with no args (a la `gnubg`)
- Commands: `new`, `roll`, `move`, `hint`, `show`, `save`, `load`, `quit`
- Tab completion for commands, `show` subtargets, and saved-game names
- Command history persisted to `~/.ndbg_history`
- Saved-game name → game-id mappings in `~/.ndbg/games.json` (`load <name>` reattaches across sessions)
- Move notation matches gnubg: `8/5`, `bar/20`, `6/off`, chained `13/8/5`
- Adds `ApiService.confirmTurn()` to support end-of-turn finalization from the shell

## Branching note

Targets `main` directly (skipping `development` → `staging`) per the fast-iteration exception the maintainer granted for this repo while the CLI is pre-adoption. Not the pattern for other Nodots packages.

## Test plan

- [x] `npm test` — 79/79 passing, includes new shell-{completer,dispatch,move-parser,tokenize} suites
- [x] `npm run build` clean (tsc -b --force)
- [ ] Manual smoke: `ndbg` → `new <robot-id> --robot` → `roll` → `move 8/5 6/5` → `show board` → `save smoke` → `quit` → `ndbg` → `load smoke` → state restored
- [ ] Manual smoke: tab completion against an empty buffer, after `show `, and after `load `